### PR TITLE
Add CopyOS OS design and build documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
-Noch nichts hier...
+# CopyOS – Konzept und Bauplan
+
+CopyOS ist ein bewusst minimalistisches Linux-basiertes Sicherungs-OS, das unter dem Markendach „Studio Justin Braun“ firmiert. Dieses Repository bündelt den technischen Bauplan, Branding-Richtlinien sowie Build-Anweisungen, um ein auf USB-Sticks lauffähiges System zu erstellen, das Ordner von lokalen Laufwerken auf externe Datenträger kopiert – ohne Terminal-Expertise und mit einer geführten Schritt-für-Schritt-Oberfläche.
+
+## Ziele des Projekts
+- **Einfachheit:** Nutzer:innen sollen nur Quelle und Ziel auswählen und die Sicherung mit Enter bestätigen.
+- **Universelle Einsatzfähigkeit:** Bootfähig von USB-Sticks auf sehr alter x86-Hardware (vergleichbar zu Knoppix-Unterstützung). Moderne Plattformen werden getestet, exotische Systeme werden soweit möglich durch generische Images adressiert.
+- **Eigenständiges Branding:** Start-Splashscreen, Logo und CLI-Kommandos folgen einer modernen CopyOS-Identity.
+- **Transparenz:** Dokumentation aller Design- und Entwicklungsentscheidungen in diesem Repository.
+
+Weitere Details zur Architektur, zum UI-Fluss und zu den Custom-Kommandos befinden sich in `docs/`.
+
+## Ordnerstruktur
+- `docs/` – Technische Konzepte, UX-Flows, Branding-Assets und Build-Anleitungen.
+- `docs/assets/` – Platzhalter für Splashscreen, Logo und UI-Mockups.
+
+## Status
+Dieses Repository enthält aktuell nur Dokumentation. Die beschriebenen Schritte ermöglichen es, CopyOS mit Buildroot zu bauen und anzupassen.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,96 @@
+# CopyOS Architektur- und Buildkonzept
+
+Dieses Dokument beschreibt, wie ein minimalistisches CopyOS-Abbild erstellt wird, das auf älterer x86-Hardware läuft und sich wie gefordert ausschließlich auf das Kopieren von Ordnern konzentriert.
+
+## 1. Zielplattform und Kompatibilität
+- **Primärziel:** 32-Bit- und 64-Bit-x86-Systeme mit Legacy-BIOS (vergleichbar zu den Maschinen, auf denen Knoppix läuft).
+- **Sekundärziel:** Moderne x86- und ARM-Systeme über zusätzliche Build-Profile.
+- **Hinweis zu „allen Geräten“:** Eine bitgenaue Unterstützung sämtlicher exotischer Plattformen (z. B. Quantencomputer, historische Nicht-x86-Architekturen) ist physikalisch nicht realistisch. Stattdessen liefern wir ein generisches USB-Abbild, das dank angepasstem Kernel und modularem Init-System auf sehr breiter Legacy-Hardware einsatzfähig ist.
+
+## 2. Toolchain
+Wir nutzen **Buildroot** als Basis, weil es
+- kleine, reproduzierbare Root-Dateisysteme erzeugt,
+- BusyBox integriert (ermöglicht Custom-Kommandos),
+- U-Boot/GRUB-konforme Images für USB-Sticks erstellen kann.
+
+### Voraussetzungen
+- Aktuelle Linux-Distribution (Ubuntu, Debian oder Fedora) als Buildhost.
+- Pakete: `build-essential`, `git`, `wget`, `cpio`, `unzip`, `python3`, `libncurses5-dev`, `rsync` u. a.
+
+```bash
+sudo apt-get install build-essential git wget cpio unzip python3 libncurses5-dev rsync bc
+```
+
+## 3. Buildroot-Konfiguration
+1. Repository klonen:
+   ```bash
+   git clone https://github.com/buildroot/buildroot.git
+   cd buildroot
+   git checkout 2024.02.1
+   ```
+2. Neues Defconfig erzeugen (`configs/copyos_defconfig`), das auf `x86_64` basiert, aber `BR2_x86_32=y` als Option für Legacy-CPU aktiviert.
+3. Pakete aktivieren:
+   - `busybox` (Standard, später mit Custom-Aliases),
+   - `dialog` oder `whiptail` für TUI,
+   - `python3` (minimal) für zukünftige Erweiterungen,
+   - `rsync` und `coreutils` (für robustes Kopieren),
+   - `parted`, `lsblk`, `ntfs-3g`, `dosfstools` zur Datenträger-Erkennung.
+4. Grafikstack minimal halten (Framebuffer für Splashscreen, ggf. Plymouth-Light oder `fbsplash`), kein schweres Desktop.
+5. Init-System: `busybox init` mit eigener `/etc/inittab`.
+
+## 4. Dateisystemstruktur
+```
+/
+├── boot/              # Kernel, Initrd, Splash
+├── etc/
+│   ├── inittab        # Startet CopyOS Launcher
+│   └── copyos/
+│       ├── branding/  # Logos, Farben, Texte
+│       ├── flows/     # YAML/JSON-Beschreibung der Schritt-für-Schritt-Anleitung
+│       └── commands/  # BusyBox-Aliases bzw. Wrapper
+├── usr/
+│   └── local/
+│       ├── bin/
+│       │   ├── copyos-launcher
+│       │   ├── zeig
+│       │   ├── zu
+│       │   ├── laufwerke
+│       │   └── sicherung-start
+│       └── share/copyos/
+│           └── ui/
+└── var/log/copyos/
+```
+
+## 5. Launcher-Workflow
+1. **Splashscreen** (Bootloader → Framebuffer): Anzeige von `docs/assets/splashscreen.png` (Download aus dem angegebenen Link).
+2. **Hardware-Check:** Skript `copyos-hwcheck` sammelt Informationen über verfügbare Laufwerke (`lsblk`, `blkid`).
+3. **UI (Dialog/TUI):** `copyos-launcher` führt Nutzer:innen durch drei Schritte:
+   - Quelle wählen (Liste der Laufwerke/Ordner, wahlweise mit automatischer Suche nach bekannten Pfaden).
+   - Ziel wählen (standardmäßig der eingesteckte USB-Stick, Formatierung optional).
+   - Zusammenfassung + Bestätigung (ENTER startet Sicherung).
+4. **Kopiervorgang:** `rsync` mit Optionen `-aHAX --info=progress2` für robusten Transfer, Logging nach `/var/log/copyos/`.
+5. **Abschluss:** Meldung „Sicherung abgeschlossen“, Option zum Beenden oder Neustart.
+
+## 6. Custom-Kommandos
+Implementierung über Wrapper-Skripte in `/usr/local/bin`:
+- `zeig` → `ls --group-directories-first --color=auto`.
+- `zu <pfad>` → Shell-Wrapper für `cd` (über `busybox ash -c 'cd "$1" && exec ash'`).
+- `laufwerke` → Aufruf `lsblk -o NAME,SIZE,FSTYPE,MOUNTPOINT,LABEL`.
+- `sicherung-start` → Direkter Start des Backup-Dialogs.
+
+Die Shell wird mit einer Willkommensnachricht versehen, die diese Kommandos erklärt, falls Nutzer:innen in den Terminal-Modus wechseln.
+
+## 7. Tests & Validierung
+- **QEMU:** Automatisierte Tests mit 32-Bit- und 64-Bit-VMs.
+- **Alte Hardware:** Checkliste für reale Maschinen (Pentium III, VIA C3, Core2Duo etc.).
+- **USB-Kompatibilität:** Boot mit BIOS-only und UEFI-BIOS.
+
+## 8. Release-Artefakte
+- `copyos.img` – USB-Abbild (dd-fähig).
+- `copyos.iso` – Optionales ISO für optische Medien.
+- `SHA256SUMS` & Signaturen.
+
+## 9. Weiteres Vorgehen
+- UI-Prototyp (Mockups in `docs/ui-flow.md`).
+- Lokalisierung (Deutsch/Englisch).
+- Automatisierte Backups & Reporting (Optionale zukünftige Features).

--- a/docs/branding.md
+++ b/docs/branding.md
@@ -1,0 +1,45 @@
+# Branding-Richtlinien für CopyOS
+
+## 1. Logos & Splashscreen
+- Offizielles Splash-Image: `http://watchy.online/CopyOS.png`
+- Datei herunterladen und in `docs/assets/splashscreen.png` speichern:
+  ```bash
+  curl -L -o docs/assets/splashscreen.png http://watchy.online/CopyOS.png
+  ```
+- Logo-Variation: Weiß auf dunklem Hintergrund (#0B0E14).
+- Platzierungsregeln: Logo mittig, Claim „Sichern. Fertig.“ darunter.
+
+## 2. Farbschema
+| Verwendungszweck         | Farbwert |
+|--------------------------|---------|
+| Primär (Buttons, Links)  | `#1F4B99` |
+| Sekundär (Highlights)    | `#00C4B3` |
+| Hintergrund dunkel       | `#0B0E14` |
+| Hintergrund hell (Karten)| `#121826` |
+| Text primär              | `#FFFFFF` |
+| Text sekundär            | `#D8DEE9` |
+| Warnungen                | `#FF6B6B` |
+| Erfolg                   | `#3FCF8E` |
+
+## 3. Typografie
+- Primärschrift: **Inter** (Variable Font, SIL Open Font License)
+- Alternative: **Source Sans Pro**
+- Terminal/Monospace: **JetBrains Mono** oder **Fira Code** (für Logs)
+
+## 4. UI-Elemente
+- Buttons: Abgerundete Ecken (6px Radius), leichte Schatten (0 4px 12px rgba(0,0,0,0.2)).
+- Icons: Lineare Icons (Feather Icons Stil), 2px Strichstärke, weiß oder Sekundärfarbe.
+- Progressbar: 6px Höhe, Sekundärfarbe, auf dunkler Schiene.
+
+## 5. Tonality
+- Sprache freundlich, direkt, „Du“-Ansprache.
+- Kurze Sätze, positive Bestätigung.
+- Fehlermeldungen immer mit nächstem Schritt („Bitte USB-Stick prüfen und erneut versuchen“).
+
+## 6. Druckmaterial & Dokumente
+- DIN-A4-Template mit dunklem Titelbalken (#1F4B99) und CopyOS-Logo links.
+- QR-Code zum Download des aktuellen Images.
+
+## 7. Lizenzhinweise
+- Logo und Name „CopyOS“ © Studio Justin Braun.
+- Offene Komponenten (Linux Kernel, BusyBox, Buildroot) behalten ihre jeweiligen Lizenzen. Dokumentation zu Lizenztexten unter `docs/licenses/` (noch anzulegen).

--- a/docs/build-guide.md
+++ b/docs/build-guide.md
@@ -1,0 +1,90 @@
+# Build-Anleitung für CopyOS
+
+Diese Anleitung führt durch den kompletten Prozess vom Aufsetzen des Buildroot-Projekts bis zum Erstellen eines USB-Abbilds.
+
+## 1. Vorbereitung des Build-Hosts
+1. Ubuntu/Debian installieren.
+2. Pakete installieren:
+   ```bash
+   sudo apt-get update
+   sudo apt-get install -y build-essential git wget cpio unzip python3 libncurses5-dev rsync bc
+   ```
+3. Optional: Für grafische Mockups `inkscape` und `gimp` installieren.
+
+## 2. Buildroot einrichten
+```bash
+git clone https://github.com/buildroot/buildroot.git
+cd buildroot
+git checkout 2024.02.1
+```
+
+## 3. CopyOS-Defconfig hinzufügen
+1. Datei `configs/copyos_defconfig` erstellen (siehe Auszug unten).
+2. Wichtige Optionen:
+   ```make
+   BR2_x86_64=y
+   BR2_x86_32=y
+   BR2_TOOLCHAIN_BUILDROOT_GLIBC=y
+   BR2_LINUX_KERNEL=y
+   BR2_LINUX_KERNEL_CUSTOM_VERSION=y
+   BR2_LINUX_KERNEL_CUSTOM_VERSION_VALUE="6.6.21"
+   BR2_PACKAGE_BUSYBOX_CONFIG="board/copyos/busybox.config"
+   BR2_ROOTFS_OVERLAY="board/copyos/rootfs-overlay"
+   BR2_ROOTFS_POST_BUILD_SCRIPT="board/copyos/post-build.sh"
+   BR2_TARGET_ROOTFS_EXT2=y
+   BR2_TARGET_ROOTFS_EXT2_4=y
+   BR2_TARGET_ROOTFS_SQUASHFS=y
+   BR2_TARGET_ROOTFS_TAR=y
+   BR2_PACKAGE_RSYNC=y
+   BR2_PACKAGE_DIALOG=y
+   BR2_PACKAGE_PLYMOUTH=y
+   BR2_PACKAGE_ESPEAKUP=y
+   ```
+3. Overlay-Verzeichnis `board/copyos/` anlegen (enthält Branding, Skripte, Splashscreen).
+
+## 4. Branding integrieren
+- `board/copyos/rootfs-overlay/etc/copyos/branding/colors.json`
+- `board/copyos/rootfs-overlay/usr/local/share/copyos/ui/`
+- Splashscreen in `board/copyos/rootfs-overlay/usr/share/plymouth/themes/copyos/splash.png` (verwende Datei aus `docs/assets`).
+- Plymouth-Theme `copyos.plymouth` erstellen, das Logo und Farben nutzt.
+
+## 5. Launcher bereitstellen
+- Skript `copyos-launcher` in `board/copyos/rootfs-overlay/usr/local/bin/`.
+- Abhängigkeiten: `dialog`, `rsync`, `jq` (für JSON-Parsing der Flow-Dateien).
+- Service-Eintrag in `/etc/inittab`: `::respawn:/usr/local/bin/copyos-launcher`.
+
+## 6. Custom-Kommandos hinzufügen
+- Shell-Skripte in `board/copyos/rootfs-overlay/usr/local/bin`.
+- `chmod +x` sicherstellen.
+- Begrüßung via `/etc/profile.d`.
+
+## 7. Build starten
+```bash
+make copyos_defconfig
+make
+```
+> Hinweis: Der Build kann auf älterer Hardware mehrere Stunden dauern.
+
+## 8. Artefakte
+- Ausgabe im Verzeichnis `output/images/`.
+- `copyos.ext4` → Basis-Rootfs.
+- `bzImage` → Kernel.
+- `copyos.img` → USB-Image (ggf. via `support/scripts/genimage.sh`).
+
+## 9. Image auf USB-Stick schreiben
+```bash
+sudo dd if=output/images/copyos.img of=/dev/sdX bs=4M status=progress && sync
+```
+> `/dev/sdX` durch das Zielgerät ersetzen.
+
+## 10. Tests
+- Boot in QEMU:
+  ```bash
+  qemu-system-i386 -m 512 -hda output/images/copyos.img
+  ```
+- Optional: `qemu-system-x86_64` für 64-Bit.
+
+## 11. Wartung
+- `make menuconfig` für schnelle Anpassungen.
+- Versionsupdates: `git pull` im Buildroot-Verzeichnis, `make clean all`.
+- Dokumentation im Repo aktualisieren, wenn neue Features hinzukommen.

--- a/docs/custom-commands.md
+++ b/docs/custom-commands.md
@@ -1,0 +1,30 @@
+# CopyOS Custom-Kommandos
+
+CopyOS bietet eine kleine Auswahl deutschsprachiger Komfortbefehle, die auf BusyBox und Coreutils aufsetzen. Ziel ist es, dass auch Nutzer:innen mit minimaler Terminal-Erfahrung vertraute Begriffe vorfinden.
+
+| Befehl           | Funktion                                                            | Implementierungsidee |
+|------------------|----------------------------------------------------------------------|----------------------|
+| `zeig [pfad]`    | Verzeichnisinhalte farbig auflisten (wie `ls`)                       | Wrapper um `ls --group-directories-first --color=auto` |
+| `zu <pfad>`      | Wechselt das aktuelle Verzeichnis                                    | Shell-Funktion, die `cd` ausführt und anschließend eine neue `ash`-Instanz startet |
+| `laufwerke`      | Listet alle Blockgeräte inkl. Größe, Typ, Mountpoint                 | `lsblk -o NAME,SIZE,FSTYPE,MOUNTPOINT,LABEL,MODEL` |
+| `sicherung-start`| Startet den interaktiven Sicherungsdialog erneut                      | Aufruf von `/usr/local/bin/copyos-launcher` |
+| `hilfe`          | Zeigt eine Übersicht aller CopyOS-Kommandos                          | Anzeige eines formatierten Textblocks |
+| `logbuch`        | Öffnet das jüngste Sicherungsprotokoll in `less`                      | `less /var/log/copyos/latest.log` |
+
+## Beispiel: `zeig`
+```sh
+#!/bin/sh
+exec ls --group-directories-first --color=auto "$@"
+```
+
+## Einbindung
+1. Skripte in `/usr/local/bin` ablegen.
+2. Mit `chmod +x` ausführbar machen.
+3. Über `/etc/profile.d/copyos.sh` Begrüßungsnachricht setzen:
+   ```sh
+   echo "Willkommen bei CopyOS. Verfügbare Befehle: zeig, zu, laufwerke, sicherung-start, hilfe, logbuch"
+   ```
+
+## Tests
+- Unit-Tests via `shunit2` für Wrapper-Skripte.
+- Manuelle Tests im Fallback-Terminal.

--- a/docs/ui-flow.md
+++ b/docs/ui-flow.md
@@ -1,0 +1,74 @@
+# CopyOS UI- und Experience-Konzept
+
+Dieses Dokument beschreibt die Nutzerführung vom Boot bis zur abgeschlossenen Sicherung. Fokus: maximal einfache Bedienung ohne klassische Kommandozeilen-Eingaben.
+
+## 1. Branding & Stil
+- **Farben:**
+  - Primär: #1F4B99 (Studio Justin Braun Blau)
+  - Sekundär: #00C4B3 (Akzent für Fortschrittsanzeigen)
+  - Hintergrund: #0B0E14 (dunkel, modern)
+  - Text: #FFFFFF / #D8DEE9
+- **Typografie:** Inter oder Source Sans Pro (je nach Lizenzlage in Buildroot-Paket einbinden).
+- **Logo & Splash:** Boot-Splash zeigt `CopyOS`-Logo mit Untertitel „Studio Justin Braun“ und Claim „Sichern. Fertig.“ (siehe `docs/assets/splashscreen.png`).
+
+## 2. Bootsequenz
+1. BIOS/UEFI → GRUB/Barebox Menü mit CopyOS-Branding.
+2. Splashscreen für 3–5 Sekunden, Fortschrittsbalken auf Basis der Kernel-Initialisierung.
+3. Automatischer Start von `copyos-launcher` im Framebuffer- oder TTY-Modus.
+
+## 3. Schritt-für-Schritt-Anleitung
+
+### Bildschirm A: Willkommen
+- Headline: „Willkommen bei CopyOS“
+- Text: „Wir sichern jetzt Ihre Daten. Folgen Sie einfach den Anweisungen.“
+- Buttons: `[Weiter]` (ENTER), `[Systeminformationen]` (F10), `[Beenden]` (ESC)
+
+### Bildschirm B: Quellordner wählen
+- Liste aller erkannten Laufwerke + Dateisysteme (z. B. `C: 120 GB NTFS (Windows)`).
+- Nach Auswahl eines Laufwerks zeigt eine zweite Spalte Favoritenordner (`Dokumente`, `Desktop`, `Projekte`) + Option „Individuellen Ordner suchen“.
+- Kontext-Hilfe rechts mit Schrittbeschreibung.
+
+### Bildschirm C: Ziel wählen
+- Standardmäßig wird der CopyOS-Stick vorgeschlagen.
+- Option „Anderen Datenträger wählen“ (z. B. externe USB-Platte).
+- Checkbox „Ziel vor Sicherung leeren (Formatieren)“ mit Warnhinweis.
+
+### Bildschirm D: Zusammenfassung
+- Tabelle mit Quelle → Ziel, geschätzter Speicherbedarf, Freier Speicher.
+- Checkliste („Bitte sicherstellen, dass …“).
+- Buttons: `[Sicherung starten]`, `[Zurück]`.
+
+### Bildschirm E: Fortschritt
+- Fortschrittsbalken (rsync `--info=progress2` geparst).
+- Log-Auszug (letzte 5 Dateien).
+- Hinweis „Sie können den Vorgang mit F2 im Log-Modus beobachten“.
+
+### Bildschirm F: Abschluss
+- Erfolgsmeldung oder Fehlerhinweis.
+- Optionen: `[Log ansehen]`, `[Weitere Sicherung]`, `[Herunterfahren]`, `[Neustarten]`.
+
+## 4. Tastatursteuerung
+- ENTER = Primäre Aktion.
+- ESC = Zurück/Abbrechen (mit Sicherheitsabfrage während Sicherung).
+- F1 = Hilfe-Overlay mit Symbolerklärungen.
+- F10 = Systeminformationen (Hostname, Kernel-Version, erkannte Laufwerke).
+
+## 5. Barrierefreiheit
+- Hoher Kontrast, Tastatur-only Bedienung, optional Screenreader (espeakup) aktivierbar.
+- Schriftgrößen anpassbar über F3/F4 (größer/kleiner).
+
+## 6. Fallback-Terminal
+Sollte der Launcher fehlschlagen, wechselt das System in einen TTY mit Willkommensbanner:
+```
+CopyOS Sicherungsumgebung
+Verfügbare Befehle: zeig, zu, laufwerke, sicherung-start
+Tippen Sie `sicherung-start`, um die geführte Sicherung erneut zu starten.
+```
+
+## 7. Internationalisierung
+- Texte in YAML (`/etc/copyos/flows/de.yaml`, `en.yaml`).
+- Launcher lädt je nach Tastenkombination (F6 → Sprache wechseln).
+
+## 8. Wartungsmodus
+- Admin-Tastenkürzel (CTRL+ALT+A) öffnet Passwortabfrage.
+- Nach Authentifizierung Zugriff auf erweiterte Tools (SMART-Check, Netzwerkmounts).


### PR DESCRIPTION
## Summary
- replace the placeholder README with a project overview for CopyOS
- document the architecture, UI flow, branding, build process, and custom commands for the minimal backup OS

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e45777815c8326914dd9c62a54df5f