### PR TITLE
Document copy-and-paste build command

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,14 @@ Weitere Details zur Architektur, zum UI-Fluss und zu den Custom-Kommandos befind
 Dieses Repository enthält aktuell nur Dokumentation. Die beschriebenen Schritte ermöglichen es, CopyOS mit Buildroot zu bauen und anzupassen.
 
 ## Schnellstart: Komplettes Build mit einem Befehl
-Wer CopyOS ohne manuelle `make menuconfig`-Schritte bauen möchte, nutzt das bereitgestellte Automationsskript:
+Wenn die Einrichtung nicht klappt oder Sie sich den kompletten Ablauf kopieren möchten, nutzen Sie einfach folgenden Copy-&-Paste Einzeiler. Er installiert alle benötigten Pakete (unter Debian/Ubuntu), klont dieses Repository und startet anschließend den automatisierten Build:
 
 ```bash
-git clone https://github.com/<your-org>/CopyOS.git
-cd CopyOS
-./tools/copyos-build.sh
+sudo apt-get update && \
+  sudo apt-get install -y build-essential git wget cpio unzip python3 libncurses5-dev rsync bc && \
+  git clone https://github.com/<your-org>/CopyOS.git && \
+  cd CopyOS && \
+  ./tools/copyos-build.sh
 ```
 
 Das Skript klont Buildroot (Standard: Version `2024.02.1`), kopiert die vorkonfigurierten CopyOS-Vorlagen und startet den Build mit der Anzahl an CPU-Kernen des Systems. Nach erfolgreichem Lauf liegen die Images unter `buildroot/output/images/`.

--- a/docs/build-guide.md
+++ b/docs/build-guide.md
@@ -12,10 +12,12 @@ Diese Anleitung führt durch den kompletten Prozess vom Aufsetzen des Buildroot-
 3. Optional: Für grafische Mockups `inkscape` und `gimp` installieren.
 
 ## 2. Automatischer Komplett-Build (empfohlen)
-Wer die vorkonfigurierte Umgebung ohne manuelle Menüs bauen möchte, nutzt das CopyOS-Automationsskript. Ein einziger Copy-&-Paste-Befehl richtet Buildroot ein, übernimmt Overlays und startet den Build:
+Wer die vorkonfigurierte Umgebung ohne manuelle Menüs bauen möchte, nutzt das CopyOS-Automationsskript. Der folgende Copy-&-Paste-Einzeiler installiert zunächst alle benötigten Pakete auf Debian/Ubuntu-Systemen, richtet Buildroot ein, übernimmt Overlays und startet den Build:
 
 ```bash
-git clone https://github.com/<your-org>/CopyOS.git && \
+sudo apt-get update && \
+  sudo apt-get install -y build-essential git wget cpio unzip python3 libncurses5-dev rsync bc && \
+  git clone https://github.com/<your-org>/CopyOS.git && \
   cd CopyOS && \
   ./tools/copyos-build.sh
 ```


### PR DESCRIPTION
## Summary
- provide a copy-and-paste one-liner that installs dependencies and builds CopyOS
- mirror the same instructions in the detailed build guide for clarity

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68e4b94a52cc832687fe4ec8324b3032