### PR TITLE
Fix Buildroot sync to preserve Makefiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/buildroot/

--- a/tools/copyos-build.sh
+++ b/tools/copyos-build.sh
@@ -43,7 +43,19 @@ if [ -f "$SPLASH_SRC" ]; then
 fi
 
 echo "Übernehme CopyOS-Konfiguration und Overlays ..."
-rsync -a --delete "$TEMPLATE_ROOT/" "$BUILDROOT_DIR/"
+# Stelle sicher, dass der Zielordner existiert, bevor einzelne Komponenten
+# kopiert werden. Wir vermeiden dabei ein flächendeckendes --delete am
+# Buildroot-Stamm, damit die Buildroot-Makefiles erhalten bleiben.
+mkdir -p "$BUILDROOT_DIR/board"
+mkdir -p "$BUILDROOT_DIR/configs"
+
+# Synchronisiere ausschließlich den CopyOS-Board-Overlay.
+rsync -a --delete "$TEMPLATE_ROOT/board/copyos/" \
+  "$BUILDROOT_DIR/board/copyos/"
+
+# Installiere die CopyOS-Defconfig gezielt ins Buildroot-Configs-Verzeichnis.
+install -D -m 0644 "$TEMPLATE_ROOT/configs/copyos_defconfig" \
+  "$BUILDROOT_DIR/configs/copyos_defconfig"
 
 cd "$BUILDROOT_DIR"
 


### PR DESCRIPTION
## Summary
- avoid deleting the Buildroot checkout when copying CopyOS templates by syncing only the board overlay and defconfig
- ensure the generated Buildroot directory stays untracked by ignoring buildroot/

## Testing
- ./tools/copyos-build.sh (interrupted after Buildroot configuration)


------
https://chatgpt.com/codex/tasks/task_e_68e4bac0b52883268d313e553731763a